### PR TITLE
Make property notify

### DIFF
--- a/WpfAnalyzers.Analyzers/Helpers/EnumerableExt.cs
+++ b/WpfAnalyzers.Analyzers/Helpers/EnumerableExt.cs
@@ -36,6 +36,22 @@
             return false;
         }
 
+        internal static bool TryGetSingle<TCollection, TItem>(this TCollection source, Func<TItem, bool> selector, out TItem result)
+            where TCollection : IReadOnlyList<TItem>
+        {
+            foreach (var item in source)
+            {
+                if (selector(item))
+                {
+                    result = item;
+                    return true;
+                }
+            }
+
+            result = default(TItem);
+            return false;
+        }
+
         internal static bool TryGetFirst<TCollection, TItem>(this TCollection source, out TItem result)
             where TCollection : IReadOnlyList<TItem>
         {

--- a/WpfAnalyzers.Analyzers/Helpers/SymbolHelpers/MethodSymbolExt.cs
+++ b/WpfAnalyzers.Analyzers/Helpers/SymbolHelpers/MethodSymbolExt.cs
@@ -1,0 +1,36 @@
+﻿namespace WpfAnalyzers
+{
+    using System.Collections.Generic;
+    using System.Threading;
+
+    using Microsoft.CodeAnalysis;
+
+    internal static class MethodSymbolExt
+    {
+        internal static bool TryGetSingleDeclaration<T>(this IMethodSymbol symbol, CancellationToken cancellationToken, out SyntaxNode declaration)
+        {
+            declaration = null;
+            if (symbol == null)
+            {
+                return false;
+            }
+
+            SyntaxReference syntaxReference;
+            if (symbol.DeclaringSyntaxReferences.TryGetSingle(out syntaxReference))
+            {
+                declaration = syntaxReference.GetSyntax(cancellationToken);
+                return declaration != null;
+            }
+
+            return false;
+        }
+
+        internal static IEnumerable<SyntaxNode> Declarations(this IMethodSymbol symbol, CancellationToken cancellationToken)
+        {
+            foreach (var syntaxReference in symbol.DeclaringSyntaxReferences)
+            {
+                yield return syntaxReference.GetSyntax(cancellationToken);
+            }
+        }
+    }
+}

--- a/WpfAnalyzers.Analyzers/Helpers/SymbolHelpers/SymbolExt.cs
+++ b/WpfAnalyzers.Analyzers/Helpers/SymbolHelpers/SymbolExt.cs
@@ -1,0 +1,37 @@
+﻿namespace WpfAnalyzers
+{
+    using System.Collections.Generic;
+    using System.Threading;
+
+    using Microsoft.CodeAnalysis;
+
+    internal static class SymbolExt
+    {
+        internal static bool TryGetSingleDeclaration<T>(this ISymbol symbol, CancellationToken cancellationToken, out T declaration)
+            where T : SyntaxNode
+        {
+            declaration = null;
+            if (symbol == null)
+            {
+                return false;
+            }
+
+            SyntaxReference syntaxReference;
+            if (symbol.DeclaringSyntaxReferences.TryGetSingle(out syntaxReference))
+            {
+                declaration = syntaxReference.GetSyntax(cancellationToken) as T;
+                return declaration != null;
+            }
+
+            return false;
+        }
+
+        internal static IEnumerable<SyntaxNode> Declarations(this ISymbol symbol, CancellationToken cancellationToken)
+        {
+            foreach (var syntaxReference in symbol.DeclaringSyntaxReferences)
+            {
+                yield return syntaxReference.GetSyntax(cancellationToken);
+            }
+        }
+    }
+}

--- a/WpfAnalyzers.Analyzers/PropertyChanged/Helpers/Property.cs
+++ b/WpfAnalyzers.Analyzers/PropertyChanged/Helpers/Property.cs
@@ -43,7 +43,7 @@
             return false;
         }
 
-        private static bool IsMutableAutoProperty(PropertyDeclarationSyntax property)
+        internal static bool IsMutableAutoProperty(PropertyDeclarationSyntax property)
         {
             var accessors = property?.AccessorList?.Accessors;
             if (accessors?.Count != 2)
@@ -62,7 +62,7 @@
             return true;
         }
 
-        private static bool AssignsValueToBackingField(AccessorDeclarationSyntax setter)
+        internal static bool AssignsValueToBackingField(AccessorDeclarationSyntax setter)
         {
             using (var pooled = AssignmentWalker.Create(setter))
             {

--- a/WpfAnalyzers.Analyzers/WpfAnalyzers.Analyzers.csproj
+++ b/WpfAnalyzers.Analyzers/WpfAnalyzers.Analyzers.csproj
@@ -78,6 +78,8 @@
     <Compile Include="Helpers\SemanticModelExt.cs" />
     <Compile Include="Helpers\StringHelper.cs" />
     <Compile Include="Helpers\SymbolHelpers\FieldSymbolExt.cs" />
+    <Compile Include="Helpers\SymbolHelpers\MethodSymbolExt.cs" />
+    <Compile Include="Helpers\SymbolHelpers\SymbolExt.cs" />
     <Compile Include="Helpers\SymbolHelpers\TypeSymbolExt.cs" />
     <Compile Include="Helpers\SyntaxNodeAnalysisContextExt.cs" />
     <Compile Include="DependencyProperties\WPF0041SetMutableUsingSetCurrentValue.cs" />

--- a/WpfAnalyzers.CodeFixes/PropertyChanged/MakePropertyNotifyCodeFixProvider.cs
+++ b/WpfAnalyzers.CodeFixes/PropertyChanged/MakePropertyNotifyCodeFixProvider.cs
@@ -104,7 +104,6 @@
             return true;
         }
 
-
         private static Task<Document> ApplyConvertAutoPropertyFixAsync(
             CodeFixContext context,
             SyntaxNode syntaxRoot,

--- a/WpfAnalyzers.CodeFixes/PropertyChanged/MakePropertyNotifyCodeFixProvider.cs
+++ b/WpfAnalyzers.CodeFixes/PropertyChanged/MakePropertyNotifyCodeFixProvider.cs
@@ -1,6 +1,5 @@
 ﻿namespace WpfAnalyzers
 {
-    using System;
     using System.Collections.Immutable;
     using System.Composition;
     using System.Threading;
@@ -105,6 +104,7 @@
             return true;
         }
 
+
         private static Task<Document> ApplyConvertAutoPropertyFixAsync(
             CodeFixContext context,
             SyntaxNode syntaxRoot,
@@ -127,18 +127,18 @@
         }
 
         private static Task<Document> ApplyConvertAutoPropertyFixAsync(
-    CodeFixContext context,
-    SyntaxNode syntaxRoot,
-    PropertyDeclarationSyntax propertyDeclaration,
-    ExpressionStatementSyntax assignStatement,
-    string fieldName,
-    IMethodSymbol invoker)
+            CodeFixContext context,
+            SyntaxNode syntaxRoot,
+            PropertyDeclarationSyntax propertyDeclaration,
+            ExpressionStatementSyntax assignStatement,
+            string fieldName,
+            IMethodSymbol invoker)
         {
             var syntaxGenerator = SyntaxGenerator.GetGenerator(context.Document);
             var typeDeclaration = propertyDeclaration.FirstAncestorOrSelf<TypeDeclarationSyntax>();
 
             var newPropertyDeclaration = propertyDeclaration.WithGetterReturningBackingField(syntaxGenerator, fieldName)
-                                                            .WithNotifyingSetter(syntaxGenerator, fieldName, invoker);
+                                                            .WithNotifyingSetter(syntaxGenerator, assignStatement, fieldName, invoker);
 
             var newTypeDeclaration = typeDeclaration.ReplaceNode(propertyDeclaration, newPropertyDeclaration);
             return Task.FromResult(context.Document.WithSyntaxRoot(syntaxRoot.ReplaceNode(typeDeclaration, newTypeDeclaration)));

--- a/WpfAnalyzers.CodeFixes/PropertyChanged/MakePropertyNotifyCodeFixProvider.cs
+++ b/WpfAnalyzers.CodeFixes/PropertyChanged/MakePropertyNotifyCodeFixProvider.cs
@@ -1,26 +1,35 @@
 ﻿namespace WpfAnalyzers
 {
+    using System;
     using System.Collections.Immutable;
     using System.Composition;
+    using System.Threading;
     using System.Threading.Tasks;
 
     using Microsoft.CodeAnalysis;
+    using Microsoft.CodeAnalysis.CodeActions;
     using Microsoft.CodeAnalysis.CodeFixes;
+    using Microsoft.CodeAnalysis.CSharp.Syntax;
+    using Microsoft.CodeAnalysis.Editing;
 
     using WpfAnalyzers.PropertyChanged;
+    using WpfAnalyzers.PropertyChanged.Helpers;
 
     [ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(MakePropertyNotifyCodeFixProvider))]
     [Shared]
     internal class MakePropertyNotifyCodeFixProvider : CodeFixProvider
     {
         /// <inheritdoc/>
-        public override ImmutableArray<string> FixableDiagnosticIds { get; } = ImmutableArray.Create(WPF1010MutablePublicPropertyShouldNotify.DiagnosticId);
+        public override ImmutableArray<string> FixableDiagnosticIds { get; } =
+            ImmutableArray.Create(WPF1010MutablePublicPropertyShouldNotify.DiagnosticId);
 
         /// <inheritdoc/>
         public override async Task RegisterCodeFixesAsync(CodeFixContext context)
         {
             var syntaxRoot = await context.Document.GetSyntaxRootAsync(context.CancellationToken)
                                           .ConfigureAwait(false);
+            var semanticModel = await context.Document.GetSemanticModelAsync(context.CancellationToken)
+                                 .ConfigureAwait(false);
             foreach (var diagnostic in context.Diagnostics)
             {
                 var token = syntaxRoot.FindToken(diagnostic.Location.SourceSpan.Start);
@@ -28,7 +37,51 @@
                 {
                     continue;
                 }
+
+                var propertyDeclaration = syntaxRoot.FindNode(diagnostic.Location.SourceSpan).FirstAncestorOrSelf<PropertyDeclarationSyntax>();
+                var typeDeclaration = propertyDeclaration?.FirstAncestorOrSelf<TypeDeclarationSyntax>();
+                if (typeDeclaration == null)
+                {
+                    continue;
+                }
+
+                var type = (ITypeSymbol)ModelExtensions.GetDeclaredSymbol(semanticModel, typeDeclaration, context.CancellationToken);
+
+                IMethodSymbol invoker;
+                if (PropertyChanged.Helpers.PropertyChanged.TryGetInvoker(type, semanticModel, context.CancellationToken, out invoker))
+                {
+                    if (Property.IsMutableAutoProperty(propertyDeclaration))
+                    {
+                        context.RegisterCodeFix(
+                            CodeAction.Create(
+                                "Convert to notifying property.",
+                                _ => ApplyConvertAutoPropertyFixAsync(context, syntaxRoot, propertyDeclaration, invoker),
+                                nameof(ImplementINotifyPropertyChangedCodeFixProvider)),
+                            diagnostic);
+                    }
+                }
             }
+        }
+
+        private static Task<Document> ApplyConvertAutoPropertyFixAsync(
+            CodeFixContext context,
+            SyntaxNode syntaxRoot,
+            PropertyDeclarationSyntax propertyDeclaration,
+            IMethodSymbol invoker)
+        {
+            var syntaxGenerator = SyntaxGenerator.GetGenerator(context.Document);
+            var typeDeclaration = propertyDeclaration.FirstAncestorOrSelf<TypeDeclarationSyntax>();
+
+            var newTypeDeclaration = typeDeclaration.TrackNodes(propertyDeclaration);
+            string fieldName;
+            newTypeDeclaration = newTypeDeclaration.WithBackingField(propertyDeclaration, syntaxGenerator, out fieldName);
+
+            propertyDeclaration = newTypeDeclaration.GetCurrentNode(propertyDeclaration);
+            var newPropertyDeclaration = propertyDeclaration.WithGeterReturningBackingField(syntaxGenerator, fieldName)
+                                                            .WithNotifyingSetter(syntaxGenerator, fieldName, invoker);
+
+            newTypeDeclaration = newTypeDeclaration.ReplaceNode(propertyDeclaration, newPropertyDeclaration);
+            return Task.FromResult(context.Document.WithSyntaxRoot(syntaxRoot.ReplaceNode(typeDeclaration, newTypeDeclaration)));
         }
     }
 }

--- a/WpfAnalyzers.CodeFixes/PropertyChanged/MakePropertyNotifyHelper.cs
+++ b/WpfAnalyzers.CodeFixes/PropertyChanged/MakePropertyNotifyHelper.cs
@@ -1,0 +1,160 @@
+namespace WpfAnalyzers
+{
+    using Microsoft.CodeAnalysis;
+    using Microsoft.CodeAnalysis.CSharp;
+    using Microsoft.CodeAnalysis.CSharp.Syntax;
+    using Microsoft.CodeAnalysis.Editing;
+
+    internal static class MakePropertyNotifyHelper
+    {
+        internal static TypeDeclarationSyntax WithBackingField(
+            this TypeDeclarationSyntax typeDeclaration,
+            PropertyDeclarationSyntax property,
+            SyntaxGenerator syntaxGenerator,
+            out string fieldName)
+        {
+            var usesUnderscoreNames = typeDeclaration.UsesUnderscoreNames();
+            fieldName = usesUnderscoreNames
+                            ? $"_{property.Identifier.ValueText.ToFirstCharLower()}"
+                            : property.Identifier.ValueText.ToFirstCharLower();
+            while (typeDeclaration.HasMember(fieldName))
+            {
+                fieldName += "_";
+            }
+
+            var field = (FieldDeclarationSyntax)syntaxGenerator.FieldDeclaration(fieldName, property.Type, Accessibility.Private);
+            MemberDeclarationSyntax existsingMember;
+            if (typeDeclaration.Members.TryGetLast(x => x.IsKind(SyntaxKind.FieldDeclaration), out existsingMember))
+            {
+                return typeDeclaration.InsertNodesAfter(existsingMember, new[] { field });
+            }
+
+            if (typeDeclaration.Members.TryGetFirst(
+                x =>
+                    x.IsKind(SyntaxKind.ConstructorDeclaration) ||
+                    x.IsKind(SyntaxKind.EventFieldDeclaration) ||
+                    x.IsKind(SyntaxKind.PropertyDeclaration) ||
+                    x.IsKind(SyntaxKind.MethodDeclaration),
+                out existsingMember))
+            {
+                return typeDeclaration.InsertNodesBefore(existsingMember, new[] { field });
+            }
+
+            return (TypeDeclarationSyntax)syntaxGenerator.AddMembers(typeDeclaration, field);
+        }
+
+        internal static PropertyDeclarationSyntax WithGeterReturningBackingField(this PropertyDeclarationSyntax property, SyntaxGenerator syntaxGenerator, string field)
+        {
+            var returnStatement = field.StartsWith("_")
+                                      ? syntaxGenerator.ReturnStatement(SyntaxFactory.ParseExpression(field))
+                                      : syntaxGenerator.ReturnStatement(SyntaxFactory.ParseExpression($"this.{field}"));
+            return (PropertyDeclarationSyntax)syntaxGenerator.WithGetAccessorStatements(property, new[] { returnStatement });
+        }
+
+        internal static PropertyDeclarationSyntax WithNotifyingSetter(this PropertyDeclarationSyntax property, SyntaxGenerator syntaxGenerator, string field, IMethodSymbol invoker)
+        {
+            var statements = new[]
+                                 {
+                                     syntaxGenerator.IfValueEqualsBackingFieldReturn(field),
+                                     syntaxGenerator.AssignValueToBackingField(field),
+                                     syntaxGenerator.Invoke(property, field.StartsWith("_"), invoker),
+                                 };
+            return (PropertyDeclarationSyntax)syntaxGenerator.WithSetAccessorStatements(property, statements);
+        }
+
+        internal static bool UsesUnderscoreNames(this TypeDeclarationSyntax type)
+        {
+            foreach (var member in type.Members)
+            {
+                var field = member as FieldDeclarationSyntax;
+                if (field == null)
+                {
+                    continue;
+                }
+
+                foreach (var variable in field.Declaration.Variables)
+                {
+                    if (variable.Identifier.ValueText.StartsWith("_"))
+                    {
+                        return true;
+                    }
+                }
+            }
+
+            return false;
+        }
+
+        private static IfStatementSyntax IfValueEqualsBackingFieldReturn(this SyntaxGenerator syntaxGenerator, string fieldName)
+        {
+            var fieldAccess = fieldName.StartsWith("_")
+                                  ? fieldName
+                                  : $"this.{fieldName}";
+
+            return (IfStatementSyntax)syntaxGenerator.IfStatement(
+                SyntaxFactory.ParseExpression($"value == {fieldAccess}"),
+                new[] { SyntaxFactory.ReturnStatement() });
+        }
+
+        private static StatementSyntax AssignValueToBackingField(this SyntaxGenerator syntaxGenerator, string fieldName)
+        {
+            var fieldAccess = fieldName.StartsWith("_")
+                                  ? fieldName
+                                  : $"this.{fieldName}";
+
+            return SyntaxFactory.ParseStatement($"{fieldAccess} = value;");
+        }
+
+        // ReSharper disable once UnusedParameter.Local
+        private static StatementSyntax Invoke(this SyntaxGenerator syntaxGenerator, PropertyDeclarationSyntax property, bool usedUnderscoreNames, IMethodSymbol invoker)
+        {
+            var prefix = usedUnderscoreNames
+                             ? string.Empty
+                             : "this.";
+            var arg = $"nameof({property.Identifier.ValueText})";
+            return SyntaxFactory.ParseStatement($"{prefix}{invoker.Name}({arg});");
+        }
+
+        private static bool HasMember(this TypeDeclarationSyntax typeDeclaration, string name)
+        {
+            foreach (var member in typeDeclaration.Members)
+            {
+                var fieldDeclaration = member as BaseFieldDeclarationSyntax;
+                if (fieldDeclaration != null)
+                {
+                    foreach (var variable in fieldDeclaration.Declaration.Variables)
+                    {
+                        if (variable.Identifier.ValueText == name)
+                        {
+                            return true;
+                        }
+                    }
+
+                    continue;
+                }
+
+                var property = member as PropertyDeclarationSyntax;
+                if (property != null)
+                {
+                    if (property.Identifier.ValueText == name)
+                    {
+                        return true;
+                    }
+
+                    continue;
+                }
+            }
+
+            return false;
+        }
+
+        private static string ToFirstCharLower(this string text)
+        {
+            if (char.IsLower(text[0]))
+            {
+                return text;
+            }
+
+            return new string(char.ToLower(text[0]), 1) + text.Substring(1);
+        }
+    }
+}

--- a/WpfAnalyzers.CodeFixes/WpfAnalyzers.CodeFixes.csproj
+++ b/WpfAnalyzers.CodeFixes/WpfAnalyzers.CodeFixes.csproj
@@ -54,6 +54,7 @@
     <Compile Include="PropertyChanged\ImplementINotifyPropertyChangedCodeFixProvider.cs" />
     <Compile Include="PropertyChanged\ImplementINotifyPropertyChangedHelper.cs" />
     <Compile Include="PropertyChanged\MakePropertyNotifyCodeFixProvider.cs" />
+    <Compile Include="PropertyChanged\MakePropertyNotifyHelper.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="app.config" />

--- a/WpfAnalyzers.Test/DependencyProperties/HappyPathWithAll.cs
+++ b/WpfAnalyzers.Test/DependencyProperties/HappyPathWithAll.cs
@@ -3,7 +3,6 @@
     using System;
     using System.Collections.Generic;
     using System.Linq;
-    using System.Threading;
     using System.Threading.Tasks;
 
     using Microsoft.CodeAnalysis.Diagnostics;

--- a/WpfAnalyzers.Test/DependencyProperties/HappyPathWithAll.cs
+++ b/WpfAnalyzers.Test/DependencyProperties/HappyPathWithAll.cs
@@ -232,7 +232,7 @@ internal static class BooleanBoxes
             return true;
         }
     }";
-            await this.VerifyCSharpDiagnosticAsync(new[] { fooCode, fooControlCode, booleanBoxesCode }, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpDiagnosticAsync(new[] { fooCode, fooControlCode, booleanBoxesCode }, EmptyDiagnosticResults).ConfigureAwait(false);
         }
 
         internal override IEnumerable<DiagnosticAnalyzer> GetCSharpDiagnosticAnalyzers()

--- a/WpfAnalyzers.Test/DependencyProperties/WPF0030BackingFieldShouldBeStaticReadonly/CodeFix.cs
+++ b/WpfAnalyzers.Test/DependencyProperties/WPF0030BackingFieldShouldBeStaticReadonly/CodeFix.cs
@@ -1,6 +1,5 @@
 ﻿namespace WpfAnalyzers.Test.DependencyProperties.WPF0030BackingFieldShouldBeStaticReadonly
 {
-    using System.Threading;
     using System.Threading.Tasks;
 
     using NUnit.Framework;

--- a/WpfAnalyzers.Test/DependencyProperties/WPF0030BackingFieldShouldBeStaticReadonly/CodeFix.cs
+++ b/WpfAnalyzers.Test/DependencyProperties/WPF0030BackingFieldShouldBeStaticReadonly/CodeFix.cs
@@ -33,7 +33,7 @@
     }";
             testCode = testCode.AssertReplace("public static DependencyProperty", before + " DependencyProperty");
             var expected = this.CSharpDiagnostic().WithLocationIndicated(ref testCode).WithArguments("BarProperty", "DependencyProperty", "Bar");
-            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected).ConfigureAwait(false);
 
             var fixedCode = @"
     using System.Windows;
@@ -95,7 +95,7 @@ public class FooControl : Control
 }";
             testCode = testCode.AssertReplace("FooControl", typeName);
             var expected = this.CSharpDiagnostic().WithLocationIndicated(ref testCode).WithArguments("BarProperty");
-            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected).ConfigureAwait(false);
 
             var fixedCode = @"
 using System.Windows;
@@ -161,7 +161,7 @@ public class FooControl : Control
 }";
 
             var expected = this.CSharpDiagnostic().WithLocationIndicated(ref testCode).WithArguments("BarPropertyKey");
-            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected).ConfigureAwait(false);
 
             var fixedCode = @"
 using System.Windows;
@@ -214,7 +214,7 @@ public static class Foo
 }";
 
             var expected = this.CSharpDiagnostic().WithLocationIndicated(ref testCode).WithArguments("BarProperty", "DependencyProperty", "Bar");
-            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected).ConfigureAwait(false);
 
             var fixedCode = @"
 using System.Windows;
@@ -270,7 +270,7 @@ public static class Foo
 }";
 
             var expected = this.CSharpDiagnostic().WithLocationIndicated(ref testCode).WithArguments("BarPropertyKey");
-            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected).ConfigureAwait(false);
 
             var fixedCode = @"
 using System.Windows;

--- a/WpfAnalyzers.Test/DependencyProperties/WPF0031FieldOrder/Diagnostics.cs
+++ b/WpfAnalyzers.Test/DependencyProperties/WPF0031FieldOrder/Diagnostics.cs
@@ -35,7 +35,7 @@ public class FooControl : Control
 }";
 
             var expected = this.CSharpDiagnostic().WithLocationIndicated(ref testCode).WithArguments("BarPropertyKey", "BarProperty");
-            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected).ConfigureAwait(false);
         }
 
         [Test]
@@ -66,7 +66,7 @@ public static class Foo
 }";
 
             var expected = this.CSharpDiagnostic().WithLocationIndicated(ref testCode).WithArguments("BarPropertyKey", "BarProperty");
-            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected).ConfigureAwait(false);
         }
     }
 }

--- a/WpfAnalyzers.Test/DependencyProperties/WPF0031FieldOrder/Diagnostics.cs
+++ b/WpfAnalyzers.Test/DependencyProperties/WPF0031FieldOrder/Diagnostics.cs
@@ -1,6 +1,5 @@
 ﻿namespace WpfAnalyzers.Test.DependencyProperties.WPF0031FieldOrder
 {
-    using System.Threading;
     using System.Threading.Tasks;
 
     using NUnit.Framework;

--- a/WpfAnalyzers.Test/DependencyProperties/WPF0032ClrPropertyGetAndSetSameDependencyProperty/Diagnostics.cs
+++ b/WpfAnalyzers.Test/DependencyProperties/WPF0032ClrPropertyGetAndSetSameDependencyProperty/Diagnostics.cs
@@ -1,6 +1,5 @@
 ﻿namespace WpfAnalyzers.Test.DependencyProperties.WPF0032ClrPropertyGetAndSetSameDependencyProperty
 {
-    using System.Threading;
     using System.Threading.Tasks;
 
     using NUnit.Framework;

--- a/WpfAnalyzers.Test/DependencyProperties/WPF0032ClrPropertyGetAndSetSameDependencyProperty/Diagnostics.cs
+++ b/WpfAnalyzers.Test/DependencyProperties/WPF0032ClrPropertyGetAndSetSameDependencyProperty/Diagnostics.cs
@@ -37,7 +37,7 @@ public class FooControl : Control
     }
 }";
             var expected = this.CSharpDiagnostic().WithLocationIndicated(ref testCode).WithArguments("Bar");
-            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected).ConfigureAwait(false);
         }
     }
 }

--- a/WpfAnalyzers.Test/DependencyProperties/WPF0040SetUsingDependencyPropertyKey/CodeFix.cs
+++ b/WpfAnalyzers.Test/DependencyProperties/WPF0040SetUsingDependencyPropertyKey/CodeFix.cs
@@ -37,7 +37,7 @@ public class FooControl : Control
 }";
             testCode = testCode.AssertReplace("SetValue", method);
             var expected = this.CSharpDiagnostic().WithLocationIndicated(ref testCode).WithArguments("BarProperty", "BarPropertyKey");
-            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected).ConfigureAwait(false);
 
             var fixedCode = @"
 using System.Windows;
@@ -92,7 +92,7 @@ public static class Foo
 }";
             testCode = testCode.AssertReplace("SetValue", method);
             var expected = this.CSharpDiagnostic().WithLocationIndicated(ref testCode).WithArguments("BarProperty", "BarPropertyKey");
-            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected).ConfigureAwait(false);
 
             var fixedCode = @"
 using System.Windows;

--- a/WpfAnalyzers.Test/DependencyProperties/WPF0040SetUsingDependencyPropertyKey/CodeFix.cs
+++ b/WpfAnalyzers.Test/DependencyProperties/WPF0040SetUsingDependencyPropertyKey/CodeFix.cs
@@ -1,6 +1,5 @@
 ﻿namespace WpfAnalyzers.Test.DependencyProperties.WPF0040SetUsingDependencyPropertyKey
 {
-    using System.Threading;
     using System.Threading.Tasks;
 
     using NUnit.Framework;

--- a/WpfAnalyzers.Test/DependencyProperties/WPF0041SetMutableUsingSetCurrentValue/CodeFix.cs
+++ b/WpfAnalyzers.Test/DependencyProperties/WPF0041SetMutableUsingSetCurrentValue/CodeFix.cs
@@ -43,7 +43,7 @@ public class FooControl : Control
             var right = setExpression.Split('=')[1].Trim(' ', ';');
             testCode = testCode.AssertReplace("Bar = 1;", setExpression);
             var expected = this.CSharpDiagnostic().WithLocationIndicated(ref testCode).WithArguments("BarProperty", right);
-            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected).ConfigureAwait(false);
 
             var fixedCode = @"
 using System.Windows;
@@ -112,7 +112,7 @@ public class FooControl : Control
             var right = setExpression.Split('=')[1].Trim(' ', ';');
             testCode = testCode.AssertReplace("Bar = 1;", setExpression);
             var expected = this.CSharpDiagnostic().WithLocationIndicated(ref testCode).WithArguments("BarProperty", right);
-            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected).ConfigureAwait(false);
 
             var fixedCode = @"
 using System.Windows;
@@ -195,7 +195,7 @@ public static class Foo
             var value = Regex.Match(after, @"SetCurrentValue\(FooControl\.BarProperty, (\(double\))?(?<value>.+)\);", RegexOptions.ExplicitCapture)
                              .Groups["value"].Value;
             var expected = this.CSharpDiagnostic().WithLocationIndicated(ref testCode).WithArguments("FooControl.BarProperty", value);
-            await this.VerifyCSharpDiagnosticAsync(new[] { testCode, fooControlCode }, new[] { expected }, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpDiagnosticAsync(new[] { testCode, fooControlCode }, new[] { expected }).ConfigureAwait(false);
 
             var fixedCode = @"
 using System.Windows;
@@ -257,7 +257,7 @@ public static class Foo
                 "this.fooControl.↓Bar = 1;",
                 setExpression);
             var expected = this.CSharpDiagnostic().WithLocationIndicated(ref fooCode).WithArguments("FooControl.BarProperty", "1");
-            await this.VerifyCSharpDiagnosticAsync(new[] { fooCode, fooControlCode }, new[] { expected }, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpDiagnosticAsync(new[] { fooCode, fooControlCode }, new[] { expected }).ConfigureAwait(false);
 
             var fixedCode = @"
     public class Foo
@@ -301,7 +301,7 @@ public class FooControl : Control
 }";
 
             var expected = this.CSharpDiagnostic().WithLocationIndicated(ref testCode).WithArguments("BarProperty", "value");
-            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected).ConfigureAwait(false);
 
             var fixedCode = @"
 using System.Windows;
@@ -356,7 +356,7 @@ public class FooControl : TextBox
     }
 }";
             var expected = this.CSharpDiagnostic().WithLocationIndicated(ref testCode).WithArguments("BarProperty", "1.0");
-            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected).ConfigureAwait(false);
 
             var fixedCode = @"
 using System.Windows;
@@ -410,7 +410,7 @@ public class FooControl : TextBox
     }
 }";
             var expected = this.CSharpDiagnostic().WithLocationIndicated(ref testCode).WithArguments("ValueProperty", "1.0");
-            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected).ConfigureAwait(false);
 
             var fixedCode = @"
 using System.Windows;
@@ -464,7 +464,7 @@ public class FooControl<T> : TextBox
     }
 }";
             var expected = this.CSharpDiagnostic().WithLocationIndicated(ref testCode).WithArguments("ValueProperty", "1.0");
-            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected).ConfigureAwait(false);
 
             var fixedCode = @"
 using System.Windows;
@@ -525,7 +525,7 @@ public class BarControl : FooControl<int>
     }
 }";
             var expected = this.CSharpDiagnostic().WithLocationIndicated(ref testCode).WithArguments("ValueProperty", "1.0");
-            await this.VerifyCSharpDiagnosticAsync(new[] { testCode, fooControlCode }, expected, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpDiagnosticAsync(new[] { testCode, fooControlCode }, expected).ConfigureAwait(false);
 
             var fixedCode = @"
 using System.Windows;
@@ -576,7 +576,7 @@ public class Foo
     }
 }";
             var expected = this.CSharpDiagnostic().WithLocationIndicated(ref testCode).WithArguments("FooControl<int>.ValueProperty", "1.0");
-            await this.VerifyCSharpDiagnosticAsync(new[] { testCode, fooControlCode }, expected, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpDiagnosticAsync(new[] { testCode, fooControlCode }, expected).ConfigureAwait(false);
 
             var fixedCode = @"
 using System.Windows;
@@ -621,7 +621,7 @@ public class FooControl : TextBox
     }
 }";
             var expected = this.CSharpDiagnostic().WithLocationIndicated(ref testCode).WithArguments("ValueProperty", "1");
-            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected).ConfigureAwait(false);
 
             var fixedCode = @"
 using System.Windows;
@@ -663,7 +663,7 @@ public class FooControl : TextBox
     }
 }";
             var expected = this.CSharpDiagnostic().WithLocationIndicated(ref testCode).WithArguments("TextProperty", "\"abc\"");
-            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected).ConfigureAwait(false);
 
             var fixedCode = @"
 using System.Windows;
@@ -695,7 +695,7 @@ public class FooControl : TextBox
     }
 }";
             var expected = this.CSharpDiagnostic().WithLocationIndicated(ref testCode).WithArguments("TextProperty", "\"abc\"");
-            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected).ConfigureAwait(false);
 
             var fixedCode = @"
 using System.Windows;
@@ -745,7 +745,7 @@ public class FooControl : Control
             var value = Regex.Match(setExpression, @"(this\.)?SetValue\(BarProperty, (?<value>.+)\);", RegexOptions.ExplicitCapture).Groups["value"].Value;
             testCode = testCode.AssertReplace("SetValue(BarProperty, 1);", setExpression);
             var expected = this.CSharpDiagnostic().WithLocationIndicated(ref testCode).WithArguments("BarProperty", value);
-            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected).ConfigureAwait(false);
 
             var fixedCode = @"
 using System.Windows;
@@ -814,7 +814,7 @@ public class FooControl : Control
             var value = Regex.Match(setExpression, @"(this\.)?SetValue\(BarProperty, (?<value>.+)\);", RegexOptions.ExplicitCapture).Groups["value"].Value;
             testCode = testCode.AssertReplace("SetValue(BarProperty, 1);", setExpression);
             var expected = this.CSharpDiagnostic().WithLocationIndicated(ref testCode).WithArguments("BarProperty", value);
-            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected).ConfigureAwait(false);
 
             var fixedCode = @"
 using System.Windows;
@@ -900,7 +900,7 @@ public static class Foo
             var expected = this.CSharpDiagnostic()
                                .WithLocationIndicated(ref testCode)
                                .WithMessage("Use SetCurrentValue(SynchronizedProperty, e.NewValue)");
-            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected).ConfigureAwait(false);
 
             var fixedCode = @"
 using System.Windows;
@@ -971,7 +971,7 @@ public class FooControl : TextBox
             var right = setExpression.Split('=')[1].Trim(' ', ';');
             testCode = testCode.AssertReplace("Text = \"1\";", setExpression);
             var expected = this.CSharpDiagnostic().WithLocationIndicated(ref testCode).WithArguments("TextProperty", right);
-            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected).ConfigureAwait(false);
 
             var fixedCode = @"
 using System.Windows;
@@ -1010,7 +1010,7 @@ public class Foo
 
             testCode = testCode.AssertReplace("this.", thisExpression);
             var expected = this.CSharpDiagnostic().WithLocationIndicated(ref testCode).WithArguments("TextBox.TextProperty", "\"1\"");
-            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected).ConfigureAwait(false);
 
             var fixedCode = @"
 using System.Windows;
@@ -1059,7 +1059,7 @@ public class FooControl : Control
     }
 }";
             var expected = this.CSharpDiagnostic().WithLocationIndicated(ref testCode).WithArguments("BarProperty", "1");
-            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected).ConfigureAwait(false);
 
             var fixedCode = @"
 using System.Windows;

--- a/WpfAnalyzers.Test/DependencyProperties/WPF0041SetMutableUsingSetCurrentValue/CodeFix.cs
+++ b/WpfAnalyzers.Test/DependencyProperties/WPF0041SetMutableUsingSetCurrentValue/CodeFix.cs
@@ -1,7 +1,6 @@
 ﻿namespace WpfAnalyzers.Test.DependencyProperties.WPF0041SetMutableUsingSetCurrentValue
 {
     using System.Text.RegularExpressions;
-    using System.Threading;
     using System.Threading.Tasks;
 
     using NUnit.Framework;

--- a/WpfAnalyzers.Test/PropertyChanged/WPF1001StructMustNotNotifyTests.cs
+++ b/WpfAnalyzers.Test/PropertyChanged/WPF1001StructMustNotNotifyTests.cs
@@ -35,7 +35,7 @@ public struct Foo : ↓INotifyPropertyChanged
 }";
 
             var expected = this.CSharpDiagnostic().WithLocationIndicated(ref testCode).WithArguments("Foo");
-            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected).ConfigureAwait(false);
         }
 
         internal override IEnumerable<DiagnosticAnalyzer> GetCSharpDiagnosticAnalyzers()

--- a/WpfAnalyzers.Test/PropertyChanged/WPF1010MutablePublicPropertyShouldNotifyTests/CodeFix.cs
+++ b/WpfAnalyzers.Test/PropertyChanged/WPF1010MutablePublicPropertyShouldNotifyTests/CodeFix.cs
@@ -1,6 +1,5 @@
 ﻿namespace WpfAnalyzers.Test.PropertyChanged.WPF1010MutablePublicPropertyShouldNotifyTests
 {
-    using System.Threading;
     using System.Threading.Tasks;
 
     using NUnit.Framework;
@@ -9,16 +8,15 @@
 
     internal class CodeFix : CodeFixVerifier<WPF1010MutablePublicPropertyShouldNotify, MakePropertyNotifyCodeFixProvider>
     {
-        [TestCase("public int Bar { get; set; }")]
-        [TestCase("public int Bar { get; private set; }")]
-        public async Task WhenNotNotifyingAutoProperty(string property)
+        [Test]
+        public async Task AutoProperty()
         {
             var testCode = @"using System.ComponentModel;
 using System.Runtime.CompilerServices;
 
 public class Foo : INotifyPropertyChanged
 {
-     public event PropertyChangedEventHandler PropertyChanged;
+    public event PropertyChangedEventHandler PropertyChanged;
 
     ↓public int Bar { get; set; }
 
@@ -28,13 +26,167 @@ public class Foo : INotifyPropertyChanged
     }
 }";
 
-            testCode = testCode.AssertReplace("public int Bar { get; set; }", property);
             var expected = this.CSharpDiagnostic().WithLocationIndicated(ref testCode).WithArguments("Bar");
-            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected).ConfigureAwait(false);
+
+            var fixedCode = @"
+using System.ComponentModel;
+
+public class Foo : INotifyPropertyChanged
+{
+    private int bar;
+
+    public event PropertyChangedEventHandler PropertyChanged;
+
+    public int Bar
+    {
+        get
+        {
+            return this.bar;
+        }
+
+        set
+        {
+            if (value == this.bar)
+            {
+                return;
+            }
+
+            this.bar = value;
+            this.OnPropertyChanged(nameof(this.Bar));
+        }
+    }
+
+    protected virtual void OnPropertyChanged(string propertyName)
+    {
+        this.PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+    }
+}";
+            await this.VerifyCSharpFixAsync(testCode, fixedCode, allowNewCompilerDiagnostics: true)
+                    .ConfigureAwait(false);
         }
 
         [Test]
-        public async Task WhenNotNotifyingWithBackingField()
+        public async Task AutoPropertyPrivateSet()
+        {
+            var testCode = @"using System.ComponentModel;
+using System.Runtime.CompilerServices;
+
+public class Foo : INotifyPropertyChanged
+{
+     public event PropertyChangedEventHandler PropertyChanged;
+
+    ↓public int Bar { get; private set; }
+
+    protected virtual void OnPropertyChanged(string propertyName)
+    {
+        this.PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+    }
+}";
+
+            var expected = this.CSharpDiagnostic().WithLocationIndicated(ref testCode).WithArguments("Bar");
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected).ConfigureAwait(false);
+
+            var fixedCode = @"
+using System.ComponentModel;
+
+public class Foo : INotifyPropertyChanged
+{
+    private int bar;
+
+    public event PropertyChangedEventHandler PropertyChanged;
+
+    public int Bar
+    {
+        get
+        {
+            return this.bar;
+        }
+
+        private set
+        {
+            if (value == this.bar)
+            {
+                return;
+            }
+
+            this.bar = value;
+            this.OnPropertyChanged(nameof(this.Bar));
+        }
+    }
+
+    protected virtual void OnPropertyChanged(string propertyName)
+    {
+        this.PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+    }
+}";
+            await this.VerifyCSharpFixAsync(testCode, fixedCode, allowNewCompilerDiagnostics: true)
+                    .ConfigureAwait(false);
+        }
+
+        [Test]
+        public async Task AutoPropertyWhenFieldExists()
+        {
+            var testCode = @"using System.ComponentModel;
+using System.Runtime.CompilerServices;
+
+public class Foo : INotifyPropertyChanged
+{
+    private int bar;
+
+    public event PropertyChangedEventHandler PropertyChanged;
+
+    ↓public int Bar { get; set; }
+
+    protected virtual void OnPropertyChanged(string propertyName)
+    {
+        this.PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+    }
+}";
+
+            var expected = this.CSharpDiagnostic().WithLocationIndicated(ref testCode).WithArguments("Bar");
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected).ConfigureAwait(false);
+
+            var fixedCode = @"
+using System.ComponentModel;
+
+public class Foo : INotifyPropertyChanged
+{
+    private int bar;
+    private int bar1;
+
+    public event PropertyChangedEventHandler PropertyChanged;
+
+    public int Bar
+    {
+        get
+        {
+            return this.bar1;
+        }
+
+        set
+        {
+            if (value == this.bar1)
+            {
+                return;
+            }
+
+            this.bar1 = value;
+            this.OnPropertyChanged(nameof(this.Bar));
+        }
+    }
+
+    protected virtual void OnPropertyChanged(string propertyName)
+    {
+        this.PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+    }
+}";
+            await this.VerifyCSharpFixAsync(testCode, fixedCode, allowNewCompilerDiagnostics: true)
+                    .ConfigureAwait(false);
+        }
+
+        [Test]
+        public async Task WithBackingFieldExplicitName()
         {
             var testCode = @"using System.ComponentModel;
 using System.Runtime.CompilerServices;
@@ -64,7 +216,177 @@ public class Foo : INotifyPropertyChanged
 }";
 
             var expected = this.CSharpDiagnostic().WithLocationIndicated(ref testCode).WithArguments("Value");
-            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected).ConfigureAwait(false);
+
+            var fixedCode = @"using System.ComponentModel;
+
+public class Foo : INotifyPropertyChanged
+{
+    private int value;
+
+    public event PropertyChangedEventHandler PropertyChanged;
+
+    public int Value
+    {
+        get
+        {
+            return this.value;
+        }
+        private set
+        {
+            if (value == this.value)
+            {
+                return;
+            }
+
+            this.value = value;
+            this.OnPropertyChanged(nameof(this.Value));
+        }
+    }
+
+    protected virtual void OnPropertyChanged(string propertyName)
+    {
+        this.PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+    }
+}";
+            await this.VerifyCSharpFixAsync(testCode, fixedCode, allowNewCompilerDiagnostics: true)
+                    .ConfigureAwait(false);
+        }
+
+        [Test]
+        public async Task WithBackingFieldCallerMemberName()
+        {
+            var testCode = @"using System.ComponentModel;
+using System.Runtime.CompilerServices;
+
+public class Foo : INotifyPropertyChanged
+{
+    private int value;
+
+    public event PropertyChangedEventHandler PropertyChanged;
+
+    ↓public int Value
+    {
+        get
+        {
+            return this.value;
+        }
+        private set
+        {
+            this.value = value;
+        }
+    }
+
+    protected virtual void OnPropertyChanged([CallerMemberName] string propertyName = null)
+    {
+        this.PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+    }
+}";
+
+            var expected = this.CSharpDiagnostic().WithLocationIndicated(ref testCode).WithArguments("Value");
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected).ConfigureAwait(false);
+
+            var fixedCode = @"using System.ComponentModel;
+using System.Runtime.CompilerServices;
+
+public class Foo : INotifyPropertyChanged
+{
+    private int value;
+
+    public event PropertyChangedEventHandler PropertyChanged;
+
+    public int Value
+    {
+        get
+        {
+            return this.value;
+        }
+
+        private set
+        {
+            if (value == this.value)
+            {
+                return;
+            }
+
+            this.value = value;
+            this.OnPropertyChanged();
+        }
+    }
+
+    protected virtual void OnPropertyChanged([CallerMemberName] string propertyName = null)
+    {
+        this.PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+    }
+}";
+            await this.VerifyCSharpFixAsync(testCode, fixedCode, allowNewCompilerDiagnostics: true)
+                    .ConfigureAwait(false);
+        }
+
+        [Test]
+        public async Task WithBackingFieldCallerMemberNameAccessorsOnOneLine()
+        {
+            var testCode = @"    
+using System.ComponentModel;
+using System.Runtime.CompilerServices;
+
+public class Foo : INotifyPropertyChanged
+{
+    private int value;
+
+    public event PropertyChangedEventHandler PropertyChanged;
+
+    public int Value
+    {
+        get { return this.value; }
+        private set { this.value = value; }
+    }
+
+    protected virtual void OnPropertyChanged([CallerMemberName] string propertyName = null)
+    {
+        this.PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+    }
+}";
+
+            var expected = this.CSharpDiagnostic().WithLocationIndicated(ref testCode).WithArguments("Value");
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected).ConfigureAwait(false);
+
+            var fixedCode = @"
+using System.ComponentModel;
+using System.Runtime.CompilerServices;
+
+public class Foo : INotifyPropertyChanged
+{
+    private int value;
+
+    public event PropertyChangedEventHandler PropertyChanged;
+
+    public int Value
+    {
+        get
+        {
+            return this.value;
+        }
+
+        private set
+        {
+            if (value == this.value)
+            {
+                return;
+            }
+
+            this.value = value;
+            this.OnPropertyChanged();
+        }
+    }
+
+    protected virtual void OnPropertyChanged([CallerMemberName] string propertyName = null)
+    {
+        this.PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+    }
+}";
+            await this.VerifyCSharpFixAsync(testCode, fixedCode, allowNewCompilerDiagnostics: true)
+                    .ConfigureAwait(false);
         }
     }
 }

--- a/WpfAnalyzers.Test/PropertyChanged/WPF1010MutablePublicPropertyShouldNotifyTests/CodeFix.cs
+++ b/WpfAnalyzers.Test/PropertyChanged/WPF1010MutablePublicPropertyShouldNotifyTests/CodeFix.cs
@@ -316,6 +316,145 @@ public class Foo : INotifyPropertyChanged
         }
 
         [Test]
+        public async Task AutoPropertyInsertCreatedFieldSorted()
+        {
+            var testCode = @"
+using System.ComponentModel;
+
+public class Foo : INotifyPropertyChanged
+{
+    private int a;
+    private int c;
+
+    public event PropertyChangedEventHandler PropertyChanged;
+
+    public int A
+    {
+        get
+        {
+            return this.a;
+        }
+
+        set
+        {
+            if (value == this.a)
+            {
+                return;
+            }
+
+            this.a = value;
+            this.OnPropertyChanged(nameof(this.A));
+        }
+    }
+
+    ↓public int B { get; set; }
+
+    public int C
+    {
+        get
+        {
+            return this.c;
+        }
+
+        set
+        {
+            if (value == this.c)
+            {
+                return;
+            }
+
+            this.c = value;
+            this.OnPropertyChanged(nameof(this.C));
+        }
+    }
+
+    protected virtual void OnPropertyChanged(string propertyName)
+    {
+        this.PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+    }
+}";
+
+            var expected = this.CSharpDiagnostic().WithLocationIndicated(ref testCode).WithArguments("B");
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected).ConfigureAwait(false);
+
+            var fixedCode = @"
+using System.ComponentModel;
+
+public class Foo : INotifyPropertyChanged
+{
+    private int a;
+    private int b;
+    private int c;
+
+    public event PropertyChangedEventHandler PropertyChanged;
+
+    public int A
+    {
+        get
+        {
+            return this.a;
+        }
+
+        set
+        {
+            if (value == this.a)
+            {
+                return;
+            }
+
+            this.a = value;
+            this.OnPropertyChanged(nameof(this.A));
+        }
+    }
+
+    public int B
+    {
+        get
+        {
+            return this.b;
+        }
+
+        set
+        {
+            if (value == this.b)
+            {
+                return;
+            }
+
+            this.b = value;
+            this.OnPropertyChanged(nameof(this.B));
+        }
+    }
+
+    public int C
+    {
+        get
+        {
+            return this.c;
+        }
+
+        set
+        {
+            if (value == this.c)
+            {
+                return;
+            }
+
+            this.c = value;
+            this.OnPropertyChanged(nameof(this.C));
+        }
+    }
+
+    protected virtual void OnPropertyChanged(string propertyName)
+    {
+        this.PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+    }
+}";
+            await this.VerifyCSharpFixAsync(testCode, fixedCode, allowNewCompilerDiagnostics: true)
+                    .ConfigureAwait(false);
+        }
+
+        [Test]
         public async Task AutoPropertyWhenFieldExists()
         {
             var testCode = @"

--- a/WpfAnalyzers.Test/PropertyChanged/WPF1010MutablePublicPropertyShouldNotifyTests/CodeFixEquality.cs
+++ b/WpfAnalyzers.Test/PropertyChanged/WPF1010MutablePublicPropertyShouldNotifyTests/CodeFixEquality.cs
@@ -1,0 +1,772 @@
+﻿namespace WpfAnalyzers.Test.PropertyChanged.WPF1010MutablePublicPropertyShouldNotifyTests
+{
+    using System.Threading.Tasks;
+
+    using NUnit.Framework;
+
+    using WpfAnalyzers.PropertyChanged;
+
+    internal class CodeFixEquality : CodeFixVerifier<WPF1010MutablePublicPropertyShouldNotify, MakePropertyNotifyCodeFixProvider>
+    {
+        [Test]
+        public async Task Integer()
+        {
+            var testCode = @"
+using System.ComponentModel;
+
+public class Foo : INotifyPropertyChanged
+{
+    public event PropertyChangedEventHandler PropertyChanged;
+
+    ↓public int Bar { get; set; }
+
+    protected virtual void OnPropertyChanged(string propertyName)
+    {
+        this.PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+    }
+}";
+
+            var expected = this.CSharpDiagnostic().WithLocationIndicated(ref testCode).WithArguments("Bar");
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected).ConfigureAwait(false);
+
+            var fixedCode = @"
+using System.ComponentModel;
+
+public class Foo : INotifyPropertyChanged
+{
+    private int bar;
+
+    public event PropertyChangedEventHandler PropertyChanged;
+
+    public int Bar
+    {
+        get
+        {
+            return this.bar;
+        }
+
+        set
+        {
+            if (value == this.bar)
+            {
+                return;
+            }
+
+            this.bar = value;
+            this.OnPropertyChanged(nameof(this.Bar));
+        }
+    }
+
+    protected virtual void OnPropertyChanged(string propertyName)
+    {
+        this.PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+    }
+}";
+            await this.VerifyCSharpFixAsync(testCode, fixedCode, allowNewCompilerDiagnostics: true)
+                    .ConfigureAwait(false);
+        }
+
+        [TestCase("int?")]
+        [TestCase("Nullable<int>")]
+        public async Task NullableInteger(string intCode)
+        {
+            var testCode = @"
+using System;
+using System.ComponentModel;
+
+public class Foo : INotifyPropertyChanged
+{
+    public event PropertyChangedEventHandler PropertyChanged;
+
+    ↓public int? Bar { get; set; }
+
+    protected virtual void OnPropertyChanged(string propertyName)
+    {
+        this.PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+    }
+}";
+
+            testCode = testCode.AssertReplace("int?", intCode);
+            var expected = this.CSharpDiagnostic().WithLocationIndicated(ref testCode).WithArguments("Bar");
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected).ConfigureAwait(false);
+
+            var fixedCode = @"
+using System;
+using System.ComponentModel;
+
+public class Foo : INotifyPropertyChanged
+{
+    private int? bar;
+
+    public event PropertyChangedEventHandler PropertyChanged;
+
+    public int? Bar
+    {
+        get
+        {
+            return this.bar;
+        }
+
+        set
+        {
+            if (value == this.bar)
+            {
+                return;
+            }
+
+            this.bar = value;
+            this.OnPropertyChanged(nameof(this.Bar));
+        }
+    }
+
+    protected virtual void OnPropertyChanged(string propertyName)
+    {
+        this.PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+    }
+}";
+
+            fixedCode = fixedCode.AssertReplace("int?", intCode);
+            await this.VerifyCSharpFixAsync(testCode, fixedCode, allowNewCompilerDiagnostics: true)
+                    .ConfigureAwait(false);
+        }
+
+        [Test]
+        public async Task String()
+        {
+            var testCode = @"
+using System.ComponentModel;
+
+public class Foo : INotifyPropertyChanged
+{
+    public event PropertyChangedEventHandler PropertyChanged;
+
+    ↓public string Bar { get; set; }
+
+    protected virtual void OnPropertyChanged(string propertyName)
+    {
+        this.PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+    }
+}";
+
+            var expected = this.CSharpDiagnostic()
+                               .WithLocationIndicated(ref testCode)
+                               .WithArguments("Bar");
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected)
+                      .ConfigureAwait(false);
+
+            var fixedCode = @"
+using System.ComponentModel;
+
+public class Foo : INotifyPropertyChanged
+{
+    private string bar;
+
+    public event PropertyChangedEventHandler PropertyChanged;
+
+    public string Bar
+    {
+        get
+        {
+            return this.bar;
+        }
+
+        set
+        {
+            if (value == this.bar)
+            {
+                return;
+            }
+
+            this.bar = value;
+            this.OnPropertyChanged(nameof(this.Bar));
+        }
+    }
+
+    protected virtual void OnPropertyChanged(string propertyName)
+    {
+        this.PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+    }
+}";
+            await this.VerifyCSharpFixAsync(testCode, fixedCode, allowNewCompilerDiagnostics: true)
+                      .ConfigureAwait(false);
+        }
+
+        [Test]
+        public async Task ReferenceType()
+        {
+            Assert.Fail("How do we want this?");
+            var refTypeCode = @"
+public class ReferenceType
+{
+}";
+            var testCode = @"
+using System.ComponentModel;
+
+public class Foo : INotifyPropertyChanged
+{
+    public event PropertyChangedEventHandler PropertyChanged;
+
+    ↓public ReferenceType Bar { get; set; }
+
+    protected virtual void OnPropertyChanged(string propertyName)
+    {
+        this.PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+    }
+}";
+
+            var expected = this.CSharpDiagnostic()
+                               .WithLocationIndicated(ref testCode)
+                               .WithArguments("Bar");
+            await this.VerifyCSharpDiagnosticAsync(new[] { refTypeCode, testCode }, expected)
+                      .ConfigureAwait(false);
+
+            var fixedCode = @"
+using System.ComponentModel;
+
+public class Foo : INotifyPropertyChanged
+{
+    private ReferenceType bar;
+
+    public event PropertyChangedEventHandler PropertyChanged;
+
+    public ReferenceType Bar
+    {
+        get
+        {
+            return this.bar;
+        }
+
+        set
+        {
+            if (ReferenceEquals(value, this.bar))
+            {
+                return;
+            }
+
+            this.bar = value;
+            this.OnPropertyChanged(nameof(this.Bar));
+        }
+    }
+
+    protected virtual void OnPropertyChanged(string propertyName)
+    {
+        this.PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+    }
+}";
+            await this.VerifyCSharpFixAsync(new[] { refTypeCode, testCode }, new[] { refTypeCode, fixedCode }, allowNewCompilerDiagnostics: true)
+                      .ConfigureAwait(false);
+        }
+
+        [Test]
+        public async Task EquatableStruct()
+        {
+            Assert.Fail("How do we want this?");
+            var equatableStruct = @"
+public struct EquatableStruct : IEquatable<EquatableStrutct>
+{
+    public readonly int Value;
+
+    public bool Equals(EquatableStrutct other)
+    {
+        return this.Value == other.Value;
+    }
+
+    public override bool Equals(object obj)
+    {
+        if (ReferenceEquals(null, obj)) return false;
+        return obj is EquatableStrutct && Equals((EquatableStrutct)obj);
+    }
+
+    public override int GetHashCode()
+    {
+        return this.Value;
+    }
+
+    public EquatableStrutct(int value)
+    {
+        this.Value = value;
+    }
+}
+";
+            var testCode = @"
+using System.ComponentModel;
+
+public class Foo : INotifyPropertyChanged
+{
+    public event PropertyChangedEventHandler PropertyChanged;
+
+    ↓public EquatableStruct Bar { get; set; }
+
+    protected virtual void OnPropertyChanged(string propertyName)
+    {
+        this.PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+    }
+}";
+
+            var expected = this.CSharpDiagnostic()
+                               .WithLocationIndicated(ref testCode)
+                               .WithArguments("Bar");
+            await this.VerifyCSharpDiagnosticAsync(new[] { equatableStruct, testCode }, expected)
+                      .ConfigureAwait(false);
+
+            var fixedCode = @"
+using System.ComponentModel;
+
+public class Foo : INotifyPropertyChanged
+{
+    private EquatableStruct bar;
+
+    public event PropertyChangedEventHandler PropertyChanged;
+
+    public EquatableStruct Bar
+    {
+        get
+        {
+            return this.bar;
+        }
+
+        set
+        {
+            if (value.Equals(this.bar))
+            {
+                return;
+            }
+
+            this.bar = value;
+            this.OnPropertyChanged(nameof(this.Bar));
+        }
+    }
+
+    protected virtual void OnPropertyChanged(string propertyName)
+    {
+        this.PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+    }
+}";
+            await this.VerifyCSharpFixAsync(new[] { equatableStruct, testCode }, new[] { equatableStruct, fixedCode }, allowNewCompilerDiagnostics: true)
+                      .ConfigureAwait(false);
+        }
+
+        [Test]
+        public async Task NullableEquatableStruct()
+        {
+            Assert.Fail("How do we want this?");
+            var equatableStruct = @"
+public struct EquatableStruct : IEquatable<EquatableStrutct>
+{
+    public readonly int Value;
+
+    public bool Equals(EquatableStrutct other)
+    {
+        return this.Value == other.Value;
+    }
+
+    public override bool Equals(object obj)
+    {
+        if (ReferenceEquals(null, obj)) return false;
+        return obj is EquatableStrutct && Equals((EquatableStrutct)obj);
+    }
+
+    public override int GetHashCode()
+    {
+        return this.Value;
+    }
+
+    public EquatableStrutct(int value)
+    {
+        this.Value = value;
+    }
+}
+";
+            var testCode = @"
+using System.ComponentModel;
+
+public class Foo : INotifyPropertyChanged
+{
+    public event PropertyChangedEventHandler PropertyChanged;
+
+    ↓public EquatableStruct? Bar { get; set; }
+
+    protected virtual void OnPropertyChanged(string propertyName)
+    {
+        this.PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+    }
+}";
+
+            var expected = this.CSharpDiagnostic()
+                               .WithLocationIndicated(ref testCode)
+                               .WithArguments("Bar");
+            await this.VerifyCSharpDiagnosticAsync(new[] { equatableStruct, testCode }, expected)
+                      .ConfigureAwait(false);
+
+            var fixedCode = @"
+using System.ComponentModel;
+
+public class Foo : INotifyPropertyChanged
+{
+    private EquatableStruct? bar;
+
+    public event PropertyChangedEventHandler PropertyChanged;
+
+    public EquatableStruct? Bar
+    {
+        get
+        {
+            return this.bar;
+        }
+
+        set
+        {
+            if (value == this.bar)
+            {
+                return;
+            }
+
+            this.bar = value;
+            this.OnPropertyChanged(nameof(this.Bar));
+        }
+    }
+
+    protected virtual void OnPropertyChanged(string propertyName)
+    {
+        this.PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+    }
+}";
+            await this.VerifyCSharpFixAsync(new[] { equatableStruct, testCode }, new[] { equatableStruct, fixedCode }, allowNewCompilerDiagnostics: true)
+                      .ConfigureAwait(false);
+        }
+
+        [Test]
+        public async Task EquatableStructWithOpEquals()
+        {
+            Assert.Fail("How do we want this?");
+            var equatableStruct = @"
+public struct EquatableStruct : IEquatable<EquatableStrutct>
+{
+    public readonly int Value;
+
+    public bool Equals(EquatableStrutct other)
+    {
+        return this.Value == other.Value;
+    }
+
+    public static bool operator ==(EquatableStrutct left, EquatableStrutct right)
+    {
+        return left.Equals(right);
+    }
+
+    public static bool operator !=(EquatableStrutct left, EquatableStrutct right)
+    {
+        return !left.Equals(right);
+    }
+
+    public override bool Equals(object obj)
+    {
+        if (ReferenceEquals(null, obj)) return false;
+        return obj is EquatableStrutct && Equals((EquatableStrutct)obj);
+    }
+
+    public override int GetHashCode()
+    {
+        return this.Value;
+    }
+
+    public EquatableStrutct(int value)
+    {
+        this.Value = value;
+    }
+}
+";
+            var testCode = @"
+using System.ComponentModel;
+
+public class Foo : INotifyPropertyChanged
+{
+    public event PropertyChangedEventHandler PropertyChanged;
+
+    ↓public EquatableStruct Bar { get; set; }
+
+    protected virtual void OnPropertyChanged(string propertyName)
+    {
+        this.PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+    }
+}";
+
+            var expected = this.CSharpDiagnostic()
+                               .WithLocationIndicated(ref testCode)
+                               .WithArguments("Bar");
+            await this.VerifyCSharpDiagnosticAsync(new[] { equatableStruct, testCode }, expected)
+                      .ConfigureAwait(false);
+
+            var fixedCode = @"
+using System.ComponentModel;
+
+public class Foo : INotifyPropertyChanged
+{
+    private EquatableStruct bar;
+
+    public event PropertyChangedEventHandler PropertyChanged;
+
+    public EquatableStruct Bar
+    {
+        get
+        {
+            return this.bar;
+        }
+
+        set
+        {
+            if (value == this.bar)
+            {
+                return;
+            }
+
+            this.bar = value;
+            this.OnPropertyChanged(nameof(this.Bar));
+        }
+    }
+
+    protected virtual void OnPropertyChanged(string propertyName)
+    {
+        this.PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+    }
+}";
+            await this.VerifyCSharpFixAsync(new[] { equatableStruct, testCode }, new[] { equatableStruct, fixedCode }, allowNewCompilerDiagnostics: true)
+                      .ConfigureAwait(false);
+        }
+
+        [Test]
+        public async Task NullableEquatableStructOpEquals()
+        {
+            Assert.Fail("How do we want this?");
+            var equatableStruct = @"
+public struct EquatableStruct : IEquatable<EquatableStrutct>
+{
+    public readonly int Value;
+
+    public bool Equals(EquatableStrutct other)
+    {
+        return this.Value == other.Value;
+    }
+
+    public static bool operator ==(EquatableStrutct left, EquatableStrutct right)
+    {
+        return left.Equals(right);
+    }
+
+    public static bool operator !=(EquatableStrutct left, EquatableStrutct right)
+    {
+        return !left.Equals(right);
+    }
+
+    public override bool Equals(object obj)
+    {
+        if (ReferenceEquals(null, obj)) return false;
+        return obj is EquatableStrutct && Equals((EquatableStrutct)obj);
+    }
+
+    public override int GetHashCode()
+    {
+        return this.Value;
+    }
+
+    public EquatableStrutct(int value)
+    {
+        this.Value = value;
+    }
+}
+";
+            var testCode = @"
+using System.ComponentModel;
+
+public class Foo : INotifyPropertyChanged
+{
+    public event PropertyChangedEventHandler PropertyChanged;
+
+    ↓public EquatableStruct? Bar { get; set; }
+
+    protected virtual void OnPropertyChanged(string propertyName)
+    {
+        this.PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+    }
+}";
+
+            var expected = this.CSharpDiagnostic()
+                               .WithLocationIndicated(ref testCode)
+                               .WithArguments("Bar");
+            await this.VerifyCSharpDiagnosticAsync(new[] { equatableStruct, testCode }, expected)
+                      .ConfigureAwait(false);
+
+            var fixedCode = @"
+using System.ComponentModel;
+
+public class Foo : INotifyPropertyChanged
+{
+    private EquatableStruct? bar;
+
+    public event PropertyChangedEventHandler PropertyChanged;
+
+    public EquatableStruct? Bar
+    {
+        get
+        {
+            return this.bar;
+        }
+
+        set
+        {
+            if (value == this.bar)
+            {
+                return;
+            }
+
+            this.bar = value;
+            this.OnPropertyChanged(nameof(this.Bar));
+        }
+    }
+
+    protected virtual void OnPropertyChanged(string propertyName)
+    {
+        this.PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+    }
+}";
+            await this.VerifyCSharpFixAsync(new[] { equatableStruct, testCode }, new[] { equatableStruct, fixedCode }, allowNewCompilerDiagnostics: true)
+                      .ConfigureAwait(false);
+        }
+
+        [Test]
+        public async Task NotEquatableStruct()
+        {
+            Assert.Fail("How do we want this?");
+            var equatableStruct = @"
+public struct NotEquatableStruct
+{
+    public readonly int Value;
+
+    public bool Equals(EquatableStrutct other)
+    {
+        return this.Value == other.Value;
+    }
+}
+";
+            var testCode = @"
+using System.ComponentModel;
+
+public class Foo : INotifyPropertyChanged
+{
+    public event PropertyChangedEventHandler PropertyChanged;
+
+    ↓public NotEquatableStruct Bar { get; set; }
+
+    protected virtual void OnPropertyChanged(string propertyName)
+    {
+        this.PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+    }
+}";
+
+            var expected = this.CSharpDiagnostic()
+                               .WithLocationIndicated(ref testCode)
+                               .WithArguments("Bar");
+            await this.VerifyCSharpDiagnosticAsync(new[] { equatableStruct, testCode }, expected)
+                      .ConfigureAwait(false);
+
+            var fixedCode = @"
+using System.ComponentModel;
+
+public class Foo : INotifyPropertyChanged
+{
+    private NotEquatableStruct bar;
+
+    public event PropertyChangedEventHandler PropertyChanged;
+
+    public NotEquatableStruct Bar
+    {
+        get
+        {
+            return this.bar;
+        }
+
+        set
+        {
+            this.bar = value;
+            this.OnPropertyChanged(nameof(this.Bar));
+        }
+    }
+
+    protected virtual void OnPropertyChanged(string propertyName)
+    {
+        this.PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+    }
+}";
+            await this.VerifyCSharpFixAsync(new[] { equatableStruct, testCode }, new[] { equatableStruct, fixedCode }, allowNewCompilerDiagnostics: true)
+                      .ConfigureAwait(false);
+        }
+
+        [Test]
+        public async Task NullableNotEquatableStruct()
+        {
+            Assert.Fail("How do we want this?");
+            var equatableStruct = @"
+public struct NotEquatableStruct
+{
+    public readonly int Value;
+
+    public bool Equals(EquatableStrutct other)
+    {
+        return this.Value == other.Value;
+    }
+}
+";
+            var testCode = @"
+using System.ComponentModel;
+
+public class Foo : INotifyPropertyChanged
+{
+    public event PropertyChangedEventHandler PropertyChanged;
+
+    ↓public NotEquatableStruct? Bar { get; set; }
+
+    protected virtual void OnPropertyChanged(string propertyName)
+    {
+        this.PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+    }
+}";
+
+            var expected = this.CSharpDiagnostic()
+                               .WithLocationIndicated(ref testCode)
+                               .WithArguments("Bar");
+            await this.VerifyCSharpDiagnosticAsync(new[] { equatableStruct, testCode }, expected)
+                      .ConfigureAwait(false);
+
+            var fixedCode = @"
+using System.ComponentModel;
+
+public class Foo : INotifyPropertyChanged
+{
+    private NotEquatableStruct? bar;
+
+    public event PropertyChangedEventHandler PropertyChanged;
+
+    public NotEquatableStruct? Bar
+    {
+        get
+        {
+            return this.bar;
+        }
+
+        set
+        {
+            this.bar = value;
+            this.OnPropertyChanged(nameof(this.Bar));
+        }
+    }
+
+    protected virtual void OnPropertyChanged(string propertyName)
+    {
+        this.PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+    }
+}";
+            await this.VerifyCSharpFixAsync(new[] { equatableStruct, testCode }, new[] { equatableStruct, fixedCode }, allowNewCompilerDiagnostics: true)
+                      .ConfigureAwait(false);
+        }
+    }
+}

--- a/WpfAnalyzers.Test/PropertyChanged/WPF1010MutablePublicPropertyShouldNotifyTests/CodeFixEquality.cs
+++ b/WpfAnalyzers.Test/PropertyChanged/WPF1010MutablePublicPropertyShouldNotifyTests/CodeFixEquality.cs
@@ -8,10 +8,14 @@
 
     internal class CodeFixEquality : CodeFixVerifier<WPF1010MutablePublicPropertyShouldNotify, MakePropertyNotifyCodeFixProvider>
     {
-        [Test]
-        public async Task Integer()
+        [TestCase("int")]
+        [TestCase("int?")]
+        [TestCase("Nullable<int>")]
+        [TestCase("string")]
+        public async Task OpEqualsFor(string typeCode)
         {
             var testCode = @"
+using System;
 using System.ComponentModel;
 
 public class Foo : INotifyPropertyChanged
@@ -25,11 +29,12 @@ public class Foo : INotifyPropertyChanged
         this.PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
     }
 }";
-
+            testCode = testCode.AssertReplace("int", typeCode);
             var expected = this.CSharpDiagnostic().WithLocationIndicated(ref testCode).WithArguments("Bar");
             await this.VerifyCSharpDiagnosticAsync(testCode, expected).ConfigureAwait(false);
 
             var fixedCode = @"
+using System;
 using System.ComponentModel;
 
 public class Foo : INotifyPropertyChanged
@@ -62,6 +67,7 @@ public class Foo : INotifyPropertyChanged
         this.PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
     }
 }";
+            fixedCode = fixedCode.AssertReplace("int", typeCode);
             await this.VerifyCSharpFixAsync(testCode, fixedCode, allowNewCompilerDiagnostics: true)
                     .ConfigureAwait(false);
         }
@@ -645,9 +651,9 @@ public struct NotEquatableStruct
 {
     public readonly int Value;
 
-    public bool Equals(EquatableStruct other)
+    public NotEquatableStruct(int value)
     {
-        return this.Value == other.Value;
+        this.Value = value;
     }
 }
 ";
@@ -713,9 +719,9 @@ public struct NotEquatableStruct
 {
     public readonly int Value;
 
-    public bool Equals(EquatableStruct other)
+    public NotEquatableStruct(int value)
     {
-        return this.Value == other.Value;
+        this.Value = value;
     }
 }
 ";

--- a/WpfAnalyzers.Test/PropertyChanged/WPF1010MutablePublicPropertyShouldNotifyTests/CodeFixEquality.cs
+++ b/WpfAnalyzers.Test/PropertyChanged/WPF1010MutablePublicPropertyShouldNotifyTests/CodeFixEquality.cs
@@ -262,11 +262,17 @@ public class Foo : INotifyPropertyChanged
         {
             Assert.Fail("How do we want this?");
             var equatableStruct = @"
-public struct EquatableStruct : IEquatable<EquatableStrutct>
+using System;
+public struct EquatableStruct : IEquatable<EquatableStruct>
 {
     public readonly int Value;
 
-    public bool Equals(EquatableStrutct other)
+    public EquatableStruct(int value)
+    {
+        this.Value = value;
+    }
+
+    public bool Equals(EquatableStruct other)
     {
         return this.Value == other.Value;
     }
@@ -274,17 +280,12 @@ public struct EquatableStruct : IEquatable<EquatableStrutct>
     public override bool Equals(object obj)
     {
         if (ReferenceEquals(null, obj)) return false;
-        return obj is EquatableStrutct && Equals((EquatableStrutct)obj);
+        return obj is EquatableStruct && Equals((EquatableStruct)obj);
     }
 
     public override int GetHashCode()
     {
         return this.Value;
-    }
-
-    public EquatableStrutct(int value)
-    {
-        this.Value = value;
     }
 }
 ";
@@ -351,11 +352,17 @@ public class Foo : INotifyPropertyChanged
         {
             Assert.Fail("How do we want this?");
             var equatableStruct = @"
-public struct EquatableStruct : IEquatable<EquatableStrutct>
+using System;
+public struct EquatableStruct : IEquatable<EquatableStruct>
 {
     public readonly int Value;
 
-    public bool Equals(EquatableStrutct other)
+    public EquatableStruct(int value)
+    {
+        this.Value = value;
+    }
+
+    public bool Equals(EquatableStruct other)
     {
         return this.Value == other.Value;
     }
@@ -363,17 +370,12 @@ public struct EquatableStruct : IEquatable<EquatableStrutct>
     public override bool Equals(object obj)
     {
         if (ReferenceEquals(null, obj)) return false;
-        return obj is EquatableStrutct && Equals((EquatableStrutct)obj);
+        return obj is EquatableStruct && Equals((EquatableStruct)obj);
     }
 
     public override int GetHashCode()
     {
         return this.Value;
-    }
-
-    public EquatableStrutct(int value)
-    {
-        this.Value = value;
     }
 }
 ";
@@ -440,39 +442,40 @@ public class Foo : INotifyPropertyChanged
         {
             Assert.Fail("How do we want this?");
             var equatableStruct = @"
-public struct EquatableStruct : IEquatable<EquatableStrutct>
+public struct EquatableStruct : IEquatable<EquatableStruct>
 {
     public readonly int Value;
 
-    public bool Equals(EquatableStrutct other)
+
+    public EquatableStruct(int value)
     {
-        return this.Value == other.Value;
+        this.Value = value;
     }
 
-    public static bool operator ==(EquatableStrutct left, EquatableStrutct right)
+    public static bool operator ==(EquatableStruct left, EquatableStruct right)
     {
         return left.Equals(right);
     }
 
-    public static bool operator !=(EquatableStrutct left, EquatableStrutct right)
+    public static bool operator !=(EquatableStruct left, EquatableStruct right)
     {
         return !left.Equals(right);
+    }
+
+    public bool Equals(EquatableStruct other)
+    {
+        return this.Value == other.Value;
     }
 
     public override bool Equals(object obj)
     {
         if (ReferenceEquals(null, obj)) return false;
-        return obj is EquatableStrutct && Equals((EquatableStrutct)obj);
+        return obj is EquatableStruct && Equals((EquatableStruct)obj);
     }
 
     public override int GetHashCode()
     {
         return this.Value;
-    }
-
-    public EquatableStrutct(int value)
-    {
-        this.Value = value;
     }
 }
 ";
@@ -539,39 +542,39 @@ public class Foo : INotifyPropertyChanged
         {
             Assert.Fail("How do we want this?");
             var equatableStruct = @"
-public struct EquatableStruct : IEquatable<EquatableStrutct>
+public struct EquatableStruct : IEquatable<EquatableStruct>
 {
     public readonly int Value;
 
-    public bool Equals(EquatableStrutct other)
+    public EquatableStruct(int value)
     {
-        return this.Value == other.Value;
+        this.Value = value;
     }
 
-    public static bool operator ==(EquatableStrutct left, EquatableStrutct right)
+    public static bool operator ==(EquatableStruct left, EquatableStruct right)
     {
         return left.Equals(right);
     }
 
-    public static bool operator !=(EquatableStrutct left, EquatableStrutct right)
+    public static bool operator !=(EquatableStruct left, EquatableStruct right)
     {
         return !left.Equals(right);
+    }
+
+    public bool Equals(EquatableStruct other)
+    {
+        return this.Value == other.Value;
     }
 
     public override bool Equals(object obj)
     {
         if (ReferenceEquals(null, obj)) return false;
-        return obj is EquatableStrutct && Equals((EquatableStrutct)obj);
+        return obj is EquatableStruct && Equals((EquatableStruct)obj);
     }
 
     public override int GetHashCode()
     {
         return this.Value;
-    }
-
-    public EquatableStrutct(int value)
-    {
-        this.Value = value;
     }
 }
 ";
@@ -642,7 +645,7 @@ public struct NotEquatableStruct
 {
     public readonly int Value;
 
-    public bool Equals(EquatableStrutct other)
+    public bool Equals(EquatableStruct other)
     {
         return this.Value == other.Value;
     }
@@ -710,7 +713,7 @@ public struct NotEquatableStruct
 {
     public readonly int Value;
 
-    public bool Equals(EquatableStrutct other)
+    public bool Equals(EquatableStruct other)
     {
         return this.Value == other.Value;
     }

--- a/WpfAnalyzers.Test/PropertyChanged/WPF1011ImplementINotifyPropertyChangedTests/CodeFix.cs
+++ b/WpfAnalyzers.Test/PropertyChanged/WPF1011ImplementINotifyPropertyChangedTests/CodeFix.cs
@@ -24,7 +24,7 @@ public class Foo
 }";
 
             var expected = this.CSharpDiagnostic().WithLocationIndicated(ref testCode).WithMessage("Implement INotifyPropertyChanged.");
-            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected).ConfigureAwait(false);
 
             var fixedCode = @"using System.ComponentModel;
 using System.Runtime.CompilerServices;
@@ -66,7 +66,7 @@ public class Foo
 }";
 
             var expected = this.CSharpDiagnostic().WithLocationIndicated(ref testCode).WithMessage("Implement INotifyPropertyChanged.");
-            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected).ConfigureAwait(false);
 
             var fixedCode = @"using System.ComponentModel;
 using System.Runtime.CompilerServices;
@@ -107,7 +107,7 @@ public class Foo : ↓INotifyPropertyChanged
 }";
 
             var expected = this.CSharpDiagnostic("CS0246").WithLocationIndicated(ref testCode).WithMessage("The type or namespace name 'INotifyPropertyChanged' could not be found (are you missing a using directive or an assembly reference?)");
-            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected).ConfigureAwait(false);
 
             var fixedCode = @"using System.ComponentModel;
 using System.Runtime.CompilerServices;
@@ -137,7 +137,7 @@ namespace TestCode
 }";
 
             var expected = this.CSharpDiagnostic("CS0246").WithLocationIndicated(ref testCode).WithMessage("The type or namespace name 'INotifyPropertyChanged' could not be found (are you missing a using directive or an assembly reference?)");
-            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected).ConfigureAwait(false);
 
             var fixedCode = @"
 namespace TestCode
@@ -173,7 +173,7 @@ namespace TestCode
 }";
 
             var expected = this.CSharpDiagnostic("CS0246").WithLocationIndicated(ref testCode).WithMessage("The type or namespace name 'INotifyPropertyChanged' could not be found (are you missing a using directive or an assembly reference?)");
-            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected).ConfigureAwait(false);
 
             var fixedCode = @"
 namespace TestCode
@@ -210,7 +210,7 @@ namespace TestCode
 }";
 
             var expected = this.CSharpDiagnostic("CS0246").WithLocationIndicated(ref testCode).WithMessage("The type or namespace name 'INotifyPropertyChanged' could not be found (are you missing a using directive or an assembly reference?)");
-            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected).ConfigureAwait(false);
 
             var fixedCode = @"
 using System;
@@ -245,7 +245,7 @@ public class Foo : ↓INotifyPropertyChanged
 }";
 
             var expected = this.CSharpDiagnostic("CS0535").WithLocationIndicated(ref testCode).WithMessage("'Foo' does not implement interface member 'INotifyPropertyChanged.PropertyChanged'");
-            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected).ConfigureAwait(false);
 
             var fixedCode = @"
 using System.ComponentModel;

--- a/WpfAnalyzers.Test/PropertyChanged/WPF1011ImplementINotifyPropertyChangedTests/CodeFix.cs
+++ b/WpfAnalyzers.Test/PropertyChanged/WPF1011ImplementINotifyPropertyChangedTests/CodeFix.cs
@@ -3,7 +3,6 @@
     using System.Collections.Generic;
     using System.Collections.Immutable;
     using System.Linq;
-    using System.Threading;
     using System.Threading.Tasks;
 
     using Microsoft.CodeAnalysis;

--- a/WpfAnalyzers.Test/WpfAnalyzers.Test.csproj
+++ b/WpfAnalyzers.Test/WpfAnalyzers.Test.csproj
@@ -102,6 +102,7 @@
       <DesignTime>True</DesignTime>
       <DependentUpon>Resources.resx</DependentUpon>
     </Compile>
+    <Compile Include="PropertyChanged\WPF1010MutablePublicPropertyShouldNotifyTests\CodeFixEquality.cs" />
     <Compile Include="PropertyChanged\WPF1011ImplementINotifyPropertyChangedTests\CodeFix.cs" />
     <Compile Include="PropertyChanged\WPF1011ImplementINotifyPropertyChangedTests\HappyPath.cs" />
     <Compile Include="PropertyChanged\WPF1010MutablePublicPropertyShouldNotifyTests\CodeFix.cs" />


### PR DESCRIPTION
How do we want equality checks?

I'm leaning towards:
- ReferenceEquals() for reference types
- `==` for string, structs and nullable structs that have equality operator.
- a.Equals(b) for structs that are IEquatable
- No check before assign & raise for structs that do not have equality

Comment on the failing tests [here](https://github.com/JohanLarsson/WpfAnalyzers/blob/100a9c68c97b246e3b39b641771d504bac0a9597/WpfAnalyzers.Test/PropertyChanged/WPF1010MutablePublicPropertyShouldNotifyTests/CodeFixEquality.cs)
