### PR TITLE
ArgumentNullException.ThrowIfNull is no side effect

### DIFF
--- a/WpfAnalyzers.Test/WPF0042AvoidSideEffectsInClrAccessorsTests/Valid.cs
+++ b/WpfAnalyzers.Test/WPF0042AvoidSideEffectsInClrAccessorsTests/Valid.cs
@@ -359,6 +359,51 @@ namespace N
         RoslynAssert.Valid(Analyzer, code);
     }
 
+
+    [Test]
+    public static void AttachedPropertyWithNewNullChecks()
+    {
+        var code = @"
+namespace N
+{
+    using System;
+    using System.Windows;
+
+    public static class WithNullChecks
+    {
+        public static readonly DependencyProperty TextProperty = DependencyProperty.RegisterAttached(
+            ""Text"",
+            typeof(string),
+            typeof(WithNullChecks),
+            new PropertyMetadata(default(string)));
+
+        /// <summary>Helper for setting <see cref=""TextProperty""/> on <paramref name=""element""/>.</summary>
+        /// <param name=""element""><see cref=""DependencyObject""/> to set <see cref=""TextProperty""/> on.</param>
+        /// <param name=""value"">Text property value.</param>
+        public static void SetText(DependencyObject element, string? value)
+        {
+            ArgumentNullException.ThrowIfNull(element);
+
+            element.SetValue(TextProperty, value);
+        }
+
+        /// <summary>Helper for getting <see cref=""TextProperty""/> from <paramref name=""element""/>.</summary>
+        /// <param name=""element""><see cref=""DependencyObject""/> to read <see cref=""TextProperty""/> from.</param>
+        /// <returns>Text property value.</returns>
+        [AttachedPropertyBrowsableForType(typeof(DependencyObject))]
+        public static string? GetText(DependencyObject element)
+        {
+            ArgumentNullException.ThrowIfNull(element);
+
+            return (string?)element.GetValue(TextProperty);
+        }
+    }
+}";
+
+        RoslynAssert.Valid(Analyzer, code);
+    }
+
+
     [Test]
     public static void AttachedPropertyWithEmptyIfs()
     {

--- a/WpfAnalyzers/Analyzers/ClrMethodDeclarationAnalyzer.cs
+++ b/WpfAnalyzers/Analyzers/ClrMethodDeclarationAnalyzer.cs
@@ -241,6 +241,13 @@ internal class ClrMethodDeclarationAnalyzer : DiagnosticAnalyzer
             switch (statement)
             {
                 case ExpressionStatementSyntax { Expression: { } expression }
+                    when NullCheck.IsNullCheck(expression, null, CancellationToken.None, out _):
+                    continue;
+                case ExpressionStatementSyntax { Expression: InvocationExpressionSyntax { Expression: MemberAccessExpressionSyntax { Expression: IdentifierNameSyntax { } name } expression } }
+                    when name.ToString() == nameof(System.ArgumentNullException) &&
+                    expression.Name.ToString() == "ThrowIfNull":
+                    continue;
+                case ExpressionStatementSyntax { Expression: { } expression }
                     when expression == getOrSet:
                     continue;
                 case ReturnStatementSyntax { Expression: { } expression }


### PR DESCRIPTION
fixes #461 

Currently this is a straightforward check for `ArgumentNullException.ThrowIfNull`.
Should probably get updated when `Gu` packages supports the new throw methods.